### PR TITLE
Add high score tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A lightweight, fully-client-side HTML 5 match-3 game (think simplified **Candy C
 | Grid    | 8 × 8 CSS Grid, emoji candies |
 | Input   | Touch, mouse, and keyboard (arrow keys + Space) |
 | Rules   | Swap adjacent candies, clear runs ≥ 3, chain reactions, 20-move limit |
-| Scoring | +10 pts / candy removed |
+| Scoring | +10 pts / candy removed, persistent high score |
 | UX      | 60 fps CSS transitions, no double-tap zoom |
 | PWA     | `manifest.webmanifest` + offline cache (`sw.js`) |
 | License | MIT |
@@ -18,8 +18,11 @@ A lightweight, fully-client-side HTML 5 match-3 game (think simplified **Candy C
 * **Mouse**: click-drag in the direction you want to swap  
 * **Keyboard**: use **← ↑ ↓ →** to move a cursor, **Space** swaps with the next key-press direction  
 
-Play it here once GitHub Pages finishes building:  
+Play it here once GitHub Pages finishes building:
 `https://<your-username>.github.io/sweet-swipe`
+
+The game keeps track of your best score in local storage so you can try to
+beat your previous high any time you open it.
 
 ---
 

--- a/game.js
+++ b/game.js
@@ -6,7 +6,10 @@ let score=0,moves=20;
 const gameEl=document.getElementById('game');
 const scoreEl=document.getElementById('score');
 const movesEl=document.getElementById('moves');
+const highScoreEl=document.getElementById('high-score');
+let highScore = parseInt(localStorage.getItem('highScore')) || 0;
 const modal=document.getElementById('modal');
+const modalText=document.getElementById('modal-text');
 const playAgain=document.getElementById('play-again');
 let cursor=0,selected=null;
 
@@ -19,9 +22,14 @@ function createCell(type){const d=document.createElement('div');d.className='can
 function setCandy(i,type){const cell=board[i];cell.type=type;cell.el.className='candy '+type;cell.el.textContent=emoji(type);} 
 
 function init(){gameEl.innerHTML='';board=[];for(let y=0;y<BOARD_SIZE;y++){for(let x=0;x<BOARD_SIZE;x++){let t=randomCandy();let el=createCell(t);gameEl.appendChild(el);board.push({type:t,el});}}
+highScore = parseInt(localStorage.getItem('highScore')) || highScore;
 score=0;moves=20;updateHUD();cursor=0;updateCursor();resolveMatches();}
 
-function updateHUD(){scoreEl.textContent=score;movesEl.textContent=moves;}
+function updateHUD(){
+  scoreEl.textContent=score;
+  movesEl.textContent=moves;
+  highScoreEl.textContent=highScore;
+}
 function updateCursor(){board.forEach(c=>c.el.classList.remove('cursor','selected'));board[cursor].el.classList.add('cursor');if(selected!==null)board[selected].el.classList.add('selected');}
 
 function swap(i1,i2){let t=board[i1].type;setCandy(i1,board[i2].type);setCandy(i2,t);} 
@@ -33,7 +41,14 @@ for(let x=0;x<BOARD_SIZE;x++){let run=[index(x,0)];for(let y=1;y<BOARD_SIZE;y++)
 return matches;}
 
 async function clearMatches(matches){let cleared=0;for(let m of matches){for(let i of m){board[i].el.style.animation='fade-out 0.2s forwards';board[i].type=null;cleared++;}}await wait(200);for(let i=0;i<board.length;i++){if(board[i].type===null){setCandy(i,null);board[i].el.style.opacity='0';}}
-score+=cleared*10;updateHUD();playPop();return cleared;}
+score+=cleared*10;
+if(score>highScore){
+  highScore=score;
+  localStorage.setItem('highScore',highScore);
+}
+updateHUD();
+playPop();
+return cleared;}
 
 async function applyGravity(){for(let x=0;x<BOARD_SIZE;x++){for(let y=BOARD_SIZE-1;y>=0;y--){let i=index(x,y);if(board[i].type===null){let yy=y-1;while(yy>=0&&board[index(x,yy)].type===null)yy--;if(yy>=0){setCandy(i,board[index(x,yy)].type);board[index(x,yy)].type=null;}else{setCandy(i,randomCandy());}}}}}
 
@@ -41,7 +56,14 @@ async function resolveMatches(){while(true){let m=findMatches();if(!m.length)bre
 
 async function attemptSwap(i1,i2){if(moves<=0)return;swap(i1,i2);let m=findMatches();if(m.length){moves--;updateHUD();await resolveMatches();if(moves<=0)gameOver();}else{swap(i1,i2);}updateCursor();}
 
-function gameOver(){modal.classList.remove('hidden');}
+function gameOver(){
+  if(score>=highScore){
+    modalText.textContent='New high score: '+score+'!';
+  }else{
+    modalText.textContent='Final score: '+score;
+  }
+  modal.classList.remove('hidden');
+}
 playAgain.addEventListener('click',()=>{modal.classList.add('hidden');init();});
 
 function getCellIndexFromEvent(e){let idx=[...gameEl.children].indexOf(e.target.closest('.candy'));return idx;}

--- a/index.html
+++ b/index.html
@@ -14,7 +14,9 @@
 <header>
   <h1>Sweet Swipe</h1>
   <div id="hud">
-    <span id="score">0</span> pts | <span id="moves">20</span> moves
+    <span id="score">0</span> pts |
+    <span id="moves">20</span> moves |
+    Hi: <span id="high-score">0</span>
   </div>
 </header>
 <div id="game" aria-label="Game board"></div>

--- a/sw.js
+++ b/sw.js
@@ -1,11 +1,12 @@
 // Offline cache service worker
 /* Service Worker: cache-first */
-const CACHE_NAME = 'sweet-swipe-v1';
+const CACHE_NAME = 'sweet-swipe-v2';
 const ASSETS = [
   '/',
   '/index.html',
   '/style.css',
   '/game.js',
+  '/sound.js',
   '/manifest.webmanifest'
 ];
 self.addEventListener('install', e => {


### PR DESCRIPTION
## Summary
- display a high score counter
- track best score in local storage and show game-over message
- cache sound in service worker

## Testing
- `node --check game.js`
- `node --check sound.js`
- `node --check sw.js`


------
https://chatgpt.com/codex/tasks/task_e_68424f922034832498a249b7696fe0f3