### PR TITLE
Add swap success animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A lightweight, fully-client-side HTML 5 match-3 game (think simplified **Candy C
 | Rules   | Swap adjacent candies, clear runs ≥ 3, chain reactions, 20-move limit |
 | Scoring | +10 pts / candy removed, persistent high score |
 | UX      | 60 fps CSS transitions, no double-tap zoom |
+| Animation | Pop effect on successful swaps |
 | PWA     | `manifest.webmanifest` + offline cache (`sw.js`) |
 | License | MIT |
 

--- a/game.js
+++ b/game.js
@@ -80,7 +80,25 @@ async function applyGravity(){for(let x=0;x<BOARD_SIZE;x++){for(let y=BOARD_SIZE
 
 async function resolveMatches(){while(true){let m=findMatches();if(!m.length)break;await clearMatches(m);await applyGravity();}}
 
-async function attemptSwap(i1,i2){if(moves<=0)return;swap(i1,i2);let m=findMatches();if(m.length){moves--;updateHUD();await resolveMatches();if(moves<=0)gameOver();}else{swap(i1,i2);}updateCursor();}
+async function attemptSwap(i1,i2){
+  if(moves<=0)return;
+  swap(i1,i2);
+  let m=findMatches();
+  if(m.length){
+    board[i1].el.classList.add('swap-success');
+    board[i2].el.classList.add('swap-success');
+    await wait(300);
+    board[i1].el.classList.remove('swap-success');
+    board[i2].el.classList.remove('swap-success');
+    moves--;
+    updateHUD();
+    await resolveMatches();
+    if(moves<=0)gameOver();
+  }else{
+    swap(i1,i2);
+  }
+  updateCursor();
+}
 
 function gameOver(){
   if(score>=highScore){

--- a/style.css
+++ b/style.css
@@ -15,3 +15,13 @@ body { font-family: Arial, sans-serif; background:#fafafa; text-align:center; -w
 @keyframes drop { to { transform:translateY(0); } }
 .candy.cursor{outline:3px solid #333;}
 .candy.selected{outline:3px dashed #333;}
+
+/* Animation played when a swap leads to a match */
+@keyframes swap-success {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.3); }
+  100% { transform: scale(1); }
+}
+.candy.swap-success{
+  animation: swap-success 0.3s ease;
+}


### PR DESCRIPTION
## Summary
- animate candies with a pop effect when a swap produces a match
- describe the new animation in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68425dffa7a08324a33e08938402b7a6